### PR TITLE
More flexible nameserver priority handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ resolvconf::nameserver { '8.8.8.8':
   priority => 'auto',
 }
 
+# Insert nameserver on the first line of resolv.conf without overriding
+# first configured one.
+# May be used on GCE when installing dnsmasq as resolver/forwarder to add it
+# without losing automatically configured DNS servers
+resolvconf::nameserver { '127.0.0.1':
+  priority => 'first',
+}
+
 # Set the resolve timeout to 1s
 resolvconf::option { 'timeout':
   value => '1',

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ resolvconf::nameserver { '127.0.0.1':
 # Fallback to the network resolvers
 resolvconf::nameserver { ['10.0.0.1', '10.0.0.2']: }
 
+# Automatically add nameserver after other nameservers in the end of resolv.conf
+# useful in case if some nameservers are already configured by dhclient
+resolvconf::nameserver { '8.8.8.8':
+  priority => 'auto',
+}
+
 # Set the resolve timeout to 1s
 resolvconf::option { 'timeout':
   value => '1',

--- a/lib/augeas/lenses/resolvconf.aug
+++ b/lib/augeas/lenses/resolvconf.aug
@@ -1,0 +1,40 @@
+module Resolvconf =
+    autoload xfm
+
+    let eol = Util.del_str "\n"
+    let ws = Util.del_ws_spc
+    let empty = Util.empty
+    let comment = Util.comment_generic /[ \t]*[;#][ \t]*/ "# "
+    let slash = del /\// "/"
+    let colon = Util.del_str ":"
+    let until_ws_or_eol = /[^\t ][^\n\t ]+/
+    let until_slash_ws_or_eol = /[^\/\n\t ]+/
+    let int = /[0-9]+/
+
+    let nameserver = [ key "nameserver"
+        . ws . store until_ws_or_eol . eol ]
+
+    let domain = [ key "domain" . ws . store until_ws_or_eol . eol ]
+
+    let search_domain = [ seq "search_domain" . store until_ws_or_eol ]
+    let search_domain_list = search_domain . ( ws . search_domain )*
+    let search = [ key "search" . ws . search_domain_list . eol ]
+
+    let sortlist_entry = [ seq "sortlist_entry"
+        . [ label "address" . store until_slash_ws_or_eol ]
+        . ([ slash . label "netmask" . store until_ws_or_eol ])?
+        ]
+    let sortlist_list = sortlist_entry . ( ws . sortlist_entry )*
+    let sortlist = [ key "sortlist" . ws . sortlist_list . eol ]
+
+    let boolean_option (r:regexp) = [ key "options" . ws . store r
+        . eol ]
+    let boolean_options = "debug" | "rotate" | "no-check-names" | "inet6"
+        | "ip6-bytestring" | "ip6-dotint" | "no-ip6-dotint" | "edns0"
+    let value_option (r:regexp) = [ key "options" . ws . store r
+        . [ colon . label "value" . store int . eol ] ]
+    let value_options = "ndots" | "timeout" | "attempts"
+    let options = (value_option value_options|boolean_option boolean_options)
+
+    let lns = (nameserver|domain|search|sortlist|options|empty|comment)*
+    let xfm = transform lns (incl "/etc/resolv.conf")

--- a/manifests/nameserver.pp
+++ b/manifests/nameserver.pp
@@ -32,10 +32,16 @@ define resolvconf::nameserver($priority = 'last() + 1', $ensure = 'present') {
 
   case $ensure {
     present: {
-
-      augeas { "Adding nameserver ${name} to /etc/resolv.conf":
-        changes => "set nameserver[${priority}] ${name}",
-        onlyif  => "match nameserver[.='${name}'] size == 0",
+      if ($priority == 'auto') {
+        augeas { "Adding nameserver ${name} to /etc/resolv.conf":
+          changes => "set nameserver[.='${name}'] ${name}"
+        }
+      }
+      else {
+        augeas { "Adding nameserver ${name} to /etc/resolv.conf":
+          changes => "set nameserver[${priority}] ${name}",
+          onlyif  => "match nameserver[.='${name}'] size == 0",
+        }
       }
     }
     absent: {

--- a/manifests/nameserver.pp
+++ b/manifests/nameserver.pp
@@ -32,7 +32,15 @@ define resolvconf::nameserver($priority = 'last() + 1', $ensure = 'present') {
 
   case $ensure {
     present: {
-      if ($priority == 'auto') {
+      if ($priority == 'first') {
+        augeas { "Inserting nameserver ${name} to /etc/resolv.conf":
+          changes => [
+            "ins nameserver before nameserver[1]",
+            "set nameserver[1] ${name}"
+          ],
+          onlyif  => "match nameserver[.='${name}'] size == 0"
+        }
+      } elsif ($priority == 'auto') {
         augeas { "Adding nameserver ${name} to /etc/resolv.conf":
           changes => "set nameserver[.='${name}'] ${name}"
         }


### PR DESCRIPTION
'Auto' mode can be used to add servers to the end of resolv.conf file without specifying any position by hand.

'Insert' mode is useful when dnsmasq is used and it should take over all other resolvers. But it other hand dnsmasq picks up list of DNS servers to forward requests to from resolv.conf - that's why we do not want to lose any entry from resolv.conf and need 'insert' mode, not replacing first one. 